### PR TITLE
Extend slug field to match title

### DIFF
--- a/src/form_builder/migrations/0006_auto__chg_field_form_slug.py
+++ b/src/form_builder/migrations/0006_auto__chg_field_form_slug.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'Form.slug'
+        db.alter_column(u'form_builder_form', 'slug', self.gf('django.db.models.fields.SlugField')(unique=True, max_length=255))
+
+    def backwards(self, orm):
+
+        # Changing field 'Form.slug'
+        db.alter_column(u'form_builder_form', 'slug', self.gf('django.db.models.fields.SlugField')(max_length=50, unique=True))
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'core.collabuser': {
+            'Meta': {'object_name': 'CollabUser'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '254', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '75', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '75', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '75'})
+        },
+        u'form_builder.anonymousresponse': {
+            'Meta': {'object_name': 'AnonymousResponse'},
+            'hash': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'submission_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'form_builder.field': {
+            'Meta': {'ordering': "(u'_order',)", 'object_name': 'Field'},
+            '_choices': ('django.db.models.fields.CharField', [], {'max_length': '1000', 'blank': 'True'}),
+            '_order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'default_value': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'field_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'form': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['form_builder.Form']"}),
+            'help_text': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'form_builder.fieldresponse': {
+            'Meta': {'ordering': "['form_response', 'field___order']", 'object_name': 'FieldResponse'},
+            'field': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['form_builder.Field']"}),
+            'form_response': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['form_builder.FormResponse']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'value': ('django.db.models.fields.TextField', [], {'max_length': '16777216'})
+        },
+        u'form_builder.form': {
+            'Meta': {'object_name': 'Form'},
+            'collect_users': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'confirmation_text': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'email_on_response': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'end_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instructions': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['core.CollabUser']"}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'form_builder.formresponse': {
+            'Meta': {'object_name': 'FormResponse'},
+            'archived': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'form': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'response_set'", 'to': u"orm['form_builder.Form']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'submission_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['core.CollabUser']", 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['form_builder']

--- a/src/form_builder/models.py
+++ b/src/form_builder/models.py
@@ -52,6 +52,7 @@ class Form(models.Model):
     slug = models.SlugField(_("Slug"),
                             editable=False,
                             unique=True,
+                            max_length=255,
                             blank=True)
     instructions = models.TextField(_("Form instructions"),
                                     null=True,


### PR DESCRIPTION
By default a slug has length 50, which is problematic considering it is derived from a title field that has `max_length=255`.

Ideally slug length should be a little bit longer than 255 to account for duplicates (e.g. `i-am-a-slug-2`), but Django restricts the slug length to a maximum of 255.  A better long term solution would be to shorten the title length by a few digits, but that could impact any production systems.  This solution should be suitable for almost all sane situations.