### PR TITLE
Fix bug that let closed forms still be submitted

### DIFF
--- a/src/form_builder/models.py
+++ b/src/form_builder/models.py
@@ -1,3 +1,4 @@
+from datetime import date
 from hashlib import md5
 import re
 
@@ -111,6 +112,9 @@ class Form(models.Model):
 
     def can_be_deleted(self):
         return self.response_set.count() == 0
+
+    def is_closed(self):
+        return date.today() > self.end_date
 
 
 class Field(models.Model):

--- a/src/form_builder/templates/form_builder/respond.html
+++ b/src/form_builder/templates/form_builder/respond.html
@@ -52,17 +52,26 @@
 
           {% else %}
 
-            <div class="instructions">
-              {{ user_form.instructions|urlize|linebreaks }}
-            </div>
+	    {% if user_form.is_closed %}
 
-            {% if user_form.collect_users %}
-              <p class="alert">This form will collect your user information.</p>
-            {% endif %}
+	      <p class="alert">This form has closed. Please contact {{ user_form.owner }} if you need further assistance.</p>
 
-            <form action="{% url 'form_builder:respond' user_form.slug %}" method="POST">
-              {% crispy response_form %}
-            </form>
+	    {% else %}
+
+              <div class="instructions">
+                {{ user_form.instructions|urlize|linebreaks }} 
+	        <p>This form will close on {{ user_form.end_date|date:"F jS, Y" }} at 11:59:59 p.m. Eastern Time.</p>
+              </div>
+
+              {% if user_form.collect_users %}
+                <p class="alert">This form will collect your user information.</p>
+              {% endif %}
+
+              <form action="{% url 'form_builder:respond' user_form.slug %}" method="POST">
+                {% crispy response_form %}
+              </form>
+
+	    {% endif %}
 
           {% endif %}
 

--- a/src/form_builder/templates/form_builder/respond.html
+++ b/src/form_builder/templates/form_builder/respond.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 
+{% block "title" %}{{ user_form.title }}{% endblock %}
 {% block "print_header" %}<h2 class="print_header">Form Builder</h2>{% endblock %}
 
 {% load crispy_forms_tags %}
@@ -54,7 +55,7 @@
 
 	    {% if user_form.is_closed %}
 
-	      <p class="alert">This form has closed. Please contact {{ user_form.owner }} if you need further assistance.</p>
+	      <p class="alert">This form has closed. Please contact <a href="mailto:{{ user_form.owner }}">{{ user_form.owner }}</a> if you need further assistance.</p>
 
 	    {% else %}
 

--- a/src/form_builder/views.py
+++ b/src/form_builder/views.py
@@ -173,8 +173,6 @@ def respond(req, id):
     user_form = get_object_or_404(Form, slug=id)
     already_responded = AnonymousResponse.objects.check_dupe(user_form.id,
                                                              req.user.username)
-    is_closed = user_form.is_closed()
-
     if not already_responded:
 
         if req.GET:
@@ -186,7 +184,7 @@ def respond(req, id):
         response_form = ResponseForm(
             req.POST or None, form=user_form, user=req.user)
 
-        if response_form.is_valid() and not is_closed:
+        if response_form.is_valid() and not user_form.is_closed():
             form_response = response_form.save()
 
             #set notification

--- a/src/form_builder/views.py
+++ b/src/form_builder/views.py
@@ -173,6 +173,8 @@ def respond(req, id):
     user_form = get_object_or_404(Form, slug=id)
     already_responded = AnonymousResponse.objects.check_dupe(user_form.id,
                                                              req.user.username)
+    is_closed = user_form.is_closed()
+
     if not already_responded:
 
         if req.GET:
@@ -184,7 +186,7 @@ def respond(req, id):
         response_form = ResponseForm(
             req.POST or None, form=user_form, user=req.user)
 
-        if response_form.is_valid():
+        if response_form.is_valid() and not is_closed:
             form_response = response_form.save()
 
             #set notification


### PR DESCRIPTION
The `end_date` field was never hooked up to a way to actually prevent people from submitting after a form's closing date.

This PR fixes that on both the front end and back end.


## Additions

- New `is_closed` property on the `Form` class
- Front-end logic to prevent the form from appearing on the respond page if the closing date has passed
- Back-end logic to prevent a form from being submitted if the closing date has passed
- Text to let the user know when a form is closing, or if it has already closed


## Changes

- A respond page's `<title>` will now include the form name