### PR TITLE
Make slug editable

### DIFF
--- a/src/form_builder/forms.py
+++ b/src/form_builder/forms.py
@@ -16,8 +16,8 @@ from . import models
 class FormForm(forms.ModelForm):
     class Meta:
         model = models.Form
-        fields = ('title', 'instructions', 'end_date',
-                  'confirmation_text', 'collect_users',)
+        fields = ('title', 'instructions', 'end_date', 'confirmation_text',
+                  'collect_users', 'slug')
 
     def __init__(self, *args, **kwargs):
         super(FormForm, self).__init__(*args, **kwargs)

--- a/src/form_builder/models.py
+++ b/src/form_builder/models.py
@@ -52,10 +52,12 @@ class Form(models.Model):
                              max_length=255,
                              help_text=_("Give your form a name."))
     slug = models.SlugField(_("Slug"),
-                            editable=False,
+                            editable=True,
                             unique=True,
                             max_length=255,
-                            blank=True)
+                            blank=True,
+                            help_text=_("This will modify the URL.")
+                            )
     instructions = models.TextField(_("Form instructions"),
                                     null=True,
                                     blank=True,

--- a/src/form_builder/models.py
+++ b/src/form_builder/models.py
@@ -51,13 +51,19 @@ class Form(models.Model):
     title = models.CharField(_("Title"),
                              max_length=255,
                              help_text=_("Give your form a name."))
-    slug = models.SlugField(_("Slug"),
+    slug = models.SlugField(_("URL slug"),
                             editable=True,
                             unique=True,
                             max_length=255,
                             blank=True,
-                            help_text=_("This will modify the URL.")
-                            )
+                            help_text=_("Choose a custom URL slug for this "
+                                        "form. For example, if you enter "
+                                        "'my-first-form' (without the "
+                                        "quotes), the URL to share will be "
+                                        "/forms/respond/my-first-form/. "
+                                        " If not set, the default is to use "
+                                        "the form's name in lowercase with "
+                                        "dashes instead of spaces."))
     instructions = models.TextField(_("Form instructions"),
                                     null=True,
                                     blank=True,

--- a/src/form_builder/templates/form_builder/form.html
+++ b/src/form_builder/templates/form_builder/form.html
@@ -81,7 +81,21 @@
                 {{ form.title.errors }}
             </fieldset>
 
-            <fieldset class="{{ form.instructions.html_name }}">
+            <fieldset class="{{ form.slug.html_name }}">
+                <label for="{{ form.slug.auto_id }}">
+                    {{ form.slug.label }}
+                    {% if form.slug.help_text %}
+                        <span class="help_text">
+                            <i class="icon-question-sign" title="{{ form.slug.help_text }}"></i>
+                            <span>{{ form.slug.help_text }}</span>
+                        </span>
+                    {% endif %}
+                </label>
+                {{ form.slug }}
+                {{ form.slug.errors }}
+            </fieldset>
+
+            <fieldset class="{{ form.insztructions.html_name }}">
                 <label for="{{ form.instructions.auto_id }}">
                     {{ form.instructions.label }}
                     {% if form.instructions.help_text %}

--- a/src/form_builder/templates/form_builder/form.html
+++ b/src/form_builder/templates/form_builder/form.html
@@ -95,7 +95,7 @@
                 {{ form.slug.errors }}
             </fieldset>
 
-            <fieldset class="{{ form.insztructions.html_name }}">
+            <fieldset class="{{ form.instructions.html_name }}">
                 <label for="{{ form.instructions.auto_id }}">
                     {{ form.instructions.label }}
                     {% if form.instructions.help_text %}


### PR DESCRIPTION
See GHE 725

I'm aware it might be better to display "URL" as the label instead of "Slug".  Where's the best place to do that, @Scotchester or @jimmynotjim ?  I assumed not in the template. 

## Screenshots
- You can specify the slug/URL at the time you create the form.
<img width="831" alt="screen shot 2017-04-05 at 5 14 08 pm" src="https://cloud.githubusercontent.com/assets/354591/24732072/505bfa7e-1a23-11e7-80af-35773f1ab234.png">

- If not specified, slug field gets pre-populated.  Can edit after creation.
<img width="1187" alt="screen shot 2017-04-05 at 5 08 44 pm" src="https://cloud.githubusercontent.com/assets/354591/24731984/93047f14-1a22-11e7-812e-e4e1bca04ed7.png">
