### PR TITLE
Account for forms with no end date set

### DIFF
--- a/src/form_builder/models.py
+++ b/src/form_builder/models.py
@@ -113,11 +113,10 @@ class Form(models.Model):
     def can_be_deleted(self):
         return self.response_set.count() == 0
 
+    @property
     def is_closed(self):
         if self.end_date:
             return date.today() > self.end_date
-
-        return False
 
 
 class Field(models.Model):

--- a/src/form_builder/models.py
+++ b/src/form_builder/models.py
@@ -114,7 +114,10 @@ class Form(models.Model):
         return self.response_set.count() == 0
 
     def is_closed(self):
-        return date.today() > self.end_date
+        if self.end_date:
+            return date.today() > self.end_date
+
+        return False
 
 
 class Field(models.Model):

--- a/src/form_builder/templates/form_builder/respond.html
+++ b/src/form_builder/templates/form_builder/respond.html
@@ -61,7 +61,9 @@
 
               <div class="instructions">
                 {{ user_form.instructions|urlize|linebreaks }} 
-	        <p>This form will close on {{ user_form.end_date|date:"F jS, Y" }} at 11:59:59 p.m. Eastern Time.</p>
+              {% if user_form.end_date %}
+                <p>This form will close on {{ user_form.end_date|date:"F jS, Y" }} at 11:59:59 p.m. Eastern Time.</p>
+              {% endif %}
               </div>
 
               {% if user_form.collect_users %}

--- a/src/form_builder/views.py
+++ b/src/form_builder/views.py
@@ -184,7 +184,7 @@ def respond(req, id):
         response_form = ResponseForm(
             req.POST or None, form=user_form, user=req.user)
 
-        if response_form.is_valid() and not user_form.is_closed:
+        if not user_form.is_closed and response_form.is_valid():
             form_response = response_form.save()
 
             #set notification

--- a/src/form_builder/views.py
+++ b/src/form_builder/views.py
@@ -184,7 +184,7 @@ def respond(req, id):
         response_form = ResponseForm(
             req.POST or None, form=user_form, user=req.user)
 
-        if response_form.is_valid() and not user_form.is_closed():
+        if response_form.is_valid() and not user_form.is_closed:
             form_response = response_form.save()
 
             #set notification


### PR DESCRIPTION
These changes will prevent things from breaking if a form has no set end date.

I feel like there may be a more elegant (or "Pythonic") way to write the logic in the `is_closed` method. Suggestions welcome!