### PR TITLE
Multiple form owners

### DIFF
--- a/src/form_builder/admin.py
+++ b/src/form_builder/admin.py
@@ -9,6 +9,8 @@ class FieldInline(admin.StackedInline):
 
 class FormAdmin(admin.ModelAdmin):
     inlines = [FieldInline]
+    list_display = ['title', 'date_created', 'end_date']
+    search_fields = ['title', 'owner__email']
 
 
 class FieldResponseInline(admin.StackedInline):

--- a/src/form_builder/admin.py
+++ b/src/form_builder/admin.py
@@ -9,7 +9,6 @@ class FieldInline(admin.StackedInline):
 
 class FormAdmin(admin.ModelAdmin):
     inlines = [FieldInline]
-    list_display = ['title', 'owner']
 
 
 class FieldResponseInline(admin.StackedInline):

--- a/src/form_builder/forms.py
+++ b/src/form_builder/forms.py
@@ -16,8 +16,8 @@ from . import models
 class FormForm(forms.ModelForm):
     class Meta:
         model = models.Form
-        fields = ('title', 'instructions', 'end_date', 'confirmation_text',
-                  'collect_users',)
+        fields = ('title', 'instructions', 'end_date',
+                  'confirmation_text', 'collect_users',)
 
     def __init__(self, *args, **kwargs):
         super(FormForm, self).__init__(*args, **kwargs)

--- a/src/form_builder/migrations/0007_auto__del_field_form_owner.py
+++ b/src/form_builder/migrations/0007_auto__del_field_form_owner.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'Form.owner'
+        db.delete_column(u'form_builder_form', 'owner_id')
+
+        # Adding M2M table for field owner on 'Form'
+        db.create_table(u'form_builder_form_owner', (
+            ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
+            ('form', models.ForeignKey(orm[u'form_builder.form'], null=False)),
+            ('collabuser', models.ForeignKey(orm[u'core.collabuser'], null=False))
+        ))
+        db.create_unique(u'form_builder_form_owner', ['form_id', 'collabuser_id'])
+
+
+    def backwards(self, orm):
+        # Adding field 'Form.owner'
+        db.add_column(u'form_builder_form', 'owner',
+                      self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['core.CollabUser']),
+                      keep_default=False)
+
+        # Removing M2M table for field owner on 'Form'
+        db.delete_table('form_builder_form_owner')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'core.collabuser': {
+            'Meta': {'object_name': 'CollabUser'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '254', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '75', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '75', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '75'})
+        },
+        u'form_builder.anonymousresponse': {
+            'Meta': {'object_name': 'AnonymousResponse'},
+            'hash': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'submission_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'form_builder.field': {
+            'Meta': {'ordering': "(u'_order',)", 'object_name': 'Field'},
+            '_choices': ('django.db.models.fields.CharField', [], {'max_length': '1000', 'blank': 'True'}),
+            '_order': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'default_value': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'field_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'form': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['form_builder.Form']"}),
+            'help_text': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'form_builder.fieldresponse': {
+            'Meta': {'ordering': "['form_response', 'field___order']", 'object_name': 'FieldResponse'},
+            'field': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['form_builder.Field']"}),
+            'form_response': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['form_builder.FormResponse']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'value': ('django.db.models.fields.TextField', [], {'max_length': '16777216'})
+        },
+        u'form_builder.form': {
+            'Meta': {'object_name': 'Form'},
+            'collect_users': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'confirmation_text': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'email_on_response': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'end_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instructions': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['core.CollabUser']", 'null': 'True', 'symmetrical': 'False'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'form_builder.formresponse': {
+            'Meta': {'object_name': 'FormResponse'},
+            'archived': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'form': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'response_set'", 'to': u"orm['form_builder.Form']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'submission_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['core.CollabUser']", 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['form_builder']

--- a/src/form_builder/models.py
+++ b/src/form_builder/models.py
@@ -2,6 +2,7 @@ from datetime import date
 from hashlib import md5
 import re
 
+from django import forms
 from django.db import models
 from django.utils.translation import ugettext_lazy as _, ugettext
 from collab.settings import AUTH_USER_MODEL

--- a/src/form_builder/models.py
+++ b/src/form_builder/models.py
@@ -46,7 +46,7 @@ def unique_slug(item, slug_source, slug_field):
 
 
 class Form(models.Model):
-    owner = models.ForeignKey(AUTH_USER_MODEL)
+    owner = models.ManyToManyField(AUTH_USER_MODEL, null=True)
     title = models.CharField(_("Title"),
                              max_length=255,
                              help_text=_("Give your form a name."))

--- a/src/form_builder/templates/form_builder/form.html
+++ b/src/form_builder/templates/form_builder/form.html
@@ -107,6 +107,41 @@
                 {{ form.end_date.errors }}
             </fieldset>
 
+{% comment %}
+            <fieldset class="{{ form.owner.html_name }}">
+                <label for="{{ form.owner.auto_id }}">
+                    {{ form.owner.label }}
+                    {% if form.owner.help_text %}
+                        <span class="help_text">
+                            <i class="icon-question-sign" title="{{ form.owner.help_text }}"></i>
+                            <span>{{ form.owner.help_text }}</span>
+                        </span>
+                    {% endif %}
+                </label>
+                {{ form.owner }}
+                <input type="hidden" name="owner_stub" id="owner_stub"></input>
+                {{ form.owner.errors }}
+            </fieldset>
+{% endcomment %}
+
+            <fieldset class="owners">
+                <label for="add_owner">
+                    Add an owner
+                    <span class="help_text">
+                        <i class="icon-question-sign" title="Search for a person to give them permission to edit this form and see its responses."></i>
+                        <span>Search for a person to give them permission to edit this form and see its responses.</span>
+                    </span>
+                </label>
+                <input type="text" name="add_owner" id="add_owner">
+                <input type="hidden" name="owner_stub" id="owner_stub">
+                Current owner(s):
+                <ul>
+                {% for o in custom_form.owner.values %}
+                    <li><a href="mailto:{{ o.email }}">{{ o.first_name }} {{ o.last_name }}</a></li>
+                {% endfor %}
+                </ul>
+            </fieldset>
+
         </div> <!-- /.form-options -->
 
         {{ fields.management_form }}
@@ -279,5 +314,19 @@
       $('.save-form-button').click(); //handle any unsaved changes if user unexpectedly leaves the page
     });
     {% endif %}
+
+    $(".owner input").keypress(function(event) {
+      if (event.which == 13) {
+        event.preventDefault();
+      }
+    });
+
+    $("#add_owner").autocomplete({
+      source: "{% url "search:persons_json" %}",
+      select: function(event, ui) {
+        $("#add_owner").attr("value", ui.item.label);
+        $("#owner_stub").attr("value", ui.item.stub);
+      }
+    });
 
 {% endblock "js_ready" %}

--- a/src/form_builder/templates/form_builder/form.html
+++ b/src/form_builder/templates/form_builder/form.html
@@ -45,9 +45,9 @@
           <div class="form-actions">
               <button type="submit" class="btn btn-inverse save save-form-button">Save</button>
               {% if form_action != "/forms/new/" %}
-                <button type="button" class="btn btn-inverse preview preview-form-button">Preview</button>
+                <button type="button" class="btn btn-inverse preview preview-form-button">Save & open</button>
               {% endif %}
-              <br /><button type="button" class="btn secondary-action cancel-form-button">Back to Manage Forms</button>
+              <br /><button type="button" class="btn secondary-action cancel-form-button">Back to Form Builder</button>
           </div>
 
           <div id="messages"></div>
@@ -108,23 +108,16 @@
             </fieldset>
 
 {% comment %}
-            <fieldset class="{{ form.owner.html_name }}">
-                <label for="{{ form.owner.auto_id }}">
-                    {{ form.owner.label }}
-                    {% if form.owner.help_text %}
-                        <span class="help_text">
-                            <i class="icon-question-sign" title="{{ form.owner.help_text }}"></i>
-                            <span>{{ form.owner.help_text }}</span>
-                        </span>
-                    {% endif %}
-                </label>
-                {{ form.owner }}
-                <input type="hidden" name="owner_stub" id="owner_stub"></input>
-                {{ form.owner.errors }}
-            </fieldset>
+    TODO: Add front-end indicator that added owner is pending a save.
+    TODO: Add method for removing an owner.
 {% endcomment %}
-
             <fieldset class="owners">
+                Owner(s):
+                <ul>
+                {% for o in custom_form.owner.values %}
+                    <li><a href="mailto:{{ o.email }}">{{ o.first_name }} {{ o.last_name }}</a></li>
+                {% endfor %}
+                </ul>
                 <label for="add_owner">
                     Add an owner
                     <span class="help_text">
@@ -133,13 +126,8 @@
                     </span>
                 </label>
                 <input type="text" name="add_owner" id="add_owner">
+                <p style="margin-top: -1em;font-style: italic;">You must save the form for the new owner to take effect. If you need to remove an owner, please email Intranet support.</p>
                 <input type="hidden" name="owner_stub" id="owner_stub">
-                Current owner(s):
-                <ul>
-                {% for o in custom_form.owner.values %}
-                    <li><a href="mailto:{{ o.email }}">{{ o.first_name }} {{ o.last_name }}</a></li>
-                {% endfor %}
-                </ul>
             </fieldset>
 
         </div> <!-- /.form-options -->

--- a/src/form_builder/templates/form_builder/form.html
+++ b/src/form_builder/templates/form_builder/form.html
@@ -5,8 +5,9 @@
 {% load fb_extras %}
 
 {% block "admin_content" %}
+  {% if formaction != "new" %}
   <!-- sidebar with form fields to drag over -->
-  <div class="span3 admin-tools"{% if formaction = "new" %} style="display:none"{% endif %}>
+  <div class="span3 admin-tools">
       <div class="affix-top">
           <h2>Question type</h2>
           <ul class="available-fields">
@@ -54,6 +55,7 @@
           
       </div>
   </div> <!-- /.admin-tools (sidebar with form fields to add) -->
+  {% endif %}
   
   <div class="span8 form-container">
     
@@ -107,10 +109,11 @@
                 {{ form.end_date.errors }}
             </fieldset>
 
-{% comment %}
-    TODO: Add front-end indicator that added owner is pending a save.
-    TODO: Add method for removing an owner.
-{% endcomment %}
+          {% if formaction != "new" %}
+            {% comment %}
+              TODO: Add front-end indicator that added owner is pending a save.
+              TODO: Add method for removing an owner.
+            {% endcomment %}
             <fieldset class="owners">
                 Owner(s):
                 <ul>
@@ -129,6 +132,7 @@
                 <p style="margin-top: -1em;font-style: italic;">You must save the form for the new owner to take effect. If you need to remove an owner, please email Intranet support.</p>
                 <input type="hidden" name="owner_stub" id="owner_stub">
             </fieldset>
+          {% endif %}
 
         </div> <!-- /.form-options -->
 

--- a/src/form_builder/views.py
+++ b/src/form_builder/views.py
@@ -12,6 +12,7 @@ from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_POST
 from django.contrib import messages
 
+from core.models import Person
 from core.notifications.email import EmailInfo
 from core.notifications.models import Notification
 
@@ -106,9 +107,14 @@ def edit(req, id):
     context = RequestContext(req)
     context['compact_header'] = 'compact-header'
     context["use_form_autosave"] = use_form_autosave
+    context['custom_form'] = custom_form
 
     if form_form.is_valid() and field_form_set.is_valid():
         custom_form = form_form.save()
+        if req.POST['owner_stub']:
+            person = Person.objects.get(stub=req.POST.get('owner_stub', '').strip())
+            collab_user = person.user
+            custom_form.owner.add(collab_user)
         field_form_set.save()
 
         try:
@@ -166,7 +172,7 @@ def edit(req, id):
                       form_action=reverse('form_builder:edit',
                       args=[custom_form.slug]),
                       templates=create_templates()),
-        context_instance=context)
+                      context_instance=context)
 
 
 @login_required

--- a/src/form_builder/views.py
+++ b/src/form_builder/views.py
@@ -74,7 +74,8 @@ def new(req):
 
     if form_form.is_valid() and field_form_set.is_valid():
         custom_form = form_form.save(commit=False)
-        custom_form.owner = req.user
+        custom_form.save()
+        custom_form.owner.add(req.user)
         custom_form.save()
         field_form_set = FieldFormSet(req.POST, instance=custom_form)
         if field_form_set.is_valid():

--- a/src/form_builder/views.py
+++ b/src/form_builder/views.py
@@ -199,7 +199,7 @@ def respond(req, id):
                 (req.user.first_name, req.user.last_name, user_form)
             url = "/forms/results/%s/" % user_form.slug
 
-            if user_form.owner != req.user:
+            if req.user not in user_form.owner.all():
                 if user_form.collect_users:
                     title = '%s %s submitted the "%s" form' % \
                         (req.user.first_name, req.user.last_name, user_form)
@@ -210,11 +210,15 @@ def respond(req, id):
                     text_template = 'form_respond_anonymous.txt'
                     html_template = 'form_respond_anonymous.html'
 
+                recipient_list = ''
+                for o in user_form.owner:
+                    recipient_list += o.email + ';'
+
                 email_info = EmailInfo(
                     subject=title,
                     text_template='form_builder/email/%s' % text_template,
                     html_template='form_builder/email/%s' % html_template,
-                    to_address=user_form.owner.email
+                    to_address=recipient_list
                 )
 
                 Notification.set_notification(req.user, req.user, "submitted",


### PR DESCRIPTION
This PR enables the ability for forms to have multiple owners.


## Testing (via Three Puppeteers in Vagrant)

1. Pull down this branch in `/www/collab/intra/current/form_builder/`
2. Run `/www/collab/intra/current/manage.py migrate form_builder`
3. Run `touch /www/collab/intra/current/collab/wsgi.py`
4. Load up the test server in a browser and create a new form
5. Add multiple owners to the form using the field
6. Try submitting the form and confirming that no errors are given
7. Log in as one of the other owners and verify that you can edit the form and see its responses


## Notes

- I don't think we can test email notifications to all owners until we get this on the test server.
- MVP for removing a form owner is to email the Intranet support inbox. A UI for doing that will have to happen in a later sprint.