### PR TITLE
Remove reference to owner in form closed notice

### DIFF
--- a/src/form_builder/templates/form_builder/respond.html
+++ b/src/form_builder/templates/form_builder/respond.html
@@ -55,7 +55,7 @@
 
 	    {% if user_form.is_closed %}
 
-	      <p class="alert">This form has closed. Please contact <a href="mailto:{{ user_form.owner }}">{{ user_form.owner }}</a> if you need further assistance.</p>
+	      <p class="alert">This form has closed. Please contact the form owner if you need further assistance.</p>
 
 	    {% else %}
 


### PR DESCRIPTION
This is semi-broken now that we can have multiple owners, and it's not trivial to figure out an elegant way to handle it, so let's just remove the attempt to output the/an owner.

Users should be somewhat aware of who send them the link to respond in the first place.